### PR TITLE
multiple dates input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,9 @@ fn main() {
     match matches.subcommand() {
         ("joke", Some(args)) => {
             debug!("Joke subcommand");
-            let input_date_arg = args.value_of("day");
+            let input_date_args = args.values_of("day").unwrap_or_default().collect();
             let scheduled_day_arg = args.value_of("post_on");
-            task::block_on(bot.joke(input_date_arg, scheduled_day_arg));
+            task::block_on(bot.joke(input_date_args, scheduled_day_arg));
         },
         ("reroll", Some(_args)) => {
             debug!("Reroll subcommand");


### PR DESCRIPTION
Refactor joke to process dates iteratively.
ListScheduledMessagesEndpoint is called only once at the start to compare for all requests.
Requests are all prepared before being called, so they can also be checked with each-other.

Logic is getting complicated, so it might be split into sub-methods.
Implements #8.
